### PR TITLE
Fix function name

### DIFF
--- a/ov-highlighter.el
+++ b/ov-highlighter.el
@@ -618,7 +618,7 @@ _f_: foreground   _x_: box
   ("g" ov-highlight-green "green")
   ("p" ov-highlight-pink "pink") 
   ("y" ov-highlight-yellow "yellow")
-  ("c" ov-highlight "Choose color")
+  ("c" ov-highlight-color "Choose color")
   ("f" ov-highlight-foreground "Foreground")
 
   ("[" ov-highlight-decrease-font-size "Make size smaller" :color red)


### PR DESCRIPTION
Change function name `ov-highlight` to `ov-highlight-color` in `ov-highlighter` hydra.