### PR TITLE
Fix header args not obeyed

### DIFF
--- a/scimax-org.el
+++ b/scimax-org.el
@@ -215,9 +215,6 @@ is positive, move after, and if negative, move before."
 		     `(,template ,expansion ""))))
 
 ;; * Babel settings
-;; do not evaluate code on export by default
-(setq org-export-babel-evaluate nil)
-
 ;; enable prompt-free code running
 (setq org-confirm-babel-evaluate nil
       org-confirm-elisp-link-function nil


### PR DESCRIPTION
In Org 9.0, when set `org-export-babel-evaluate' to nil, no header arguments
will be obeyed. So we remove this customization and use the default setting
instead.