### PR TITLE
Add org-edit-latex (and remove old version)

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -339,6 +339,8 @@
 
 (use-package ov)
 
+(use-package org-edit-latex)
+
 ;; this is a git submodule
 (use-package org-ref
   :ensure nil

--- a/scimax-org.el
+++ b/scimax-org.el
@@ -643,55 +643,6 @@ JUSTIFICATION is a symbol for 'left, 'center or 'right."
 
 (advice-add 'org-create-formula-image :around #'org-renumber-environment)
 
-;; * Fragment Editing
-
-(defun org-wrap-latex-fragment ()
-  "Wrap latex fragment in a latex src block"
-  (interactive)
-  (let* ((ele (org-element-context))
-         (beg (org-element-property :begin ele))
-         (end (org-element-property :end ele)))
-    (when (memq (org-element-type ele)
-                '(latex-fragment latex-environment))
-      (save-excursion
-        (goto-char (1- end))
-        (while (looking-at-p "^$")
-          (forward-line -1))
-        (end-of-line)
-        (insert "\n#+END_SRC")
-        (goto-char beg)
-        (insert "#+BEGIN_SRC latex\n")))))
-
-(defun org-unwrap-latex-fragment (&rest args)
-  "Unwrap latex fragment"
-  (interactive)
-  (let* ((ele (org-element-context))
-         (lang (org-element-property :language ele))
-         (beg (org-element-property :begin ele))
-         (end (org-element-property :end ele)))
-    (when (and (eq 'src-block
-                   (org-element-type ele))
-               (string= "latex" lang))
-      (save-excursion
-        (goto-char end)
-        (while (not (looking-at-p "^#\\+end_src"))
-          (forward-line -1))
-        (delete-region (point-at-bol) (1+ (point-at-eol)))
-        (goto-char beg)
-        (while (not (looking-at-p "^#\\+begin_src latex"))
-          (forward-line 1))
-        (delete-region (point-at-bol) (1+ (point-at-eol)))))))
-
-(defun org-wrap-latex-fragment-maybe (&rest args)
-  "Wrap a latex fragment with \"begin_src latex\" and \"end_src\" so that we could edit it like a latex src block. This only works on display math."
-  (when (save-excursion
-          (goto-char (org-element-property :begin (org-element-context)))
-          (looking-at-p "[ \t]*\\\\\\[\\|[ \t]*\\\\begin")) ; display math
-    (org-wrap-latex-fragment)))
-
-(advice-add #'org-edit-special :before #'org-wrap-latex-fragment-maybe)
-(advice-add #'org-edit-src-exit :after #'org-unwrap-latex-fragment '((depth . 100)))
-
 
 ;; * Markup commands for org-mode
 (loop for (type beginning-marker end-marker)


### PR DESCRIPTION
Usage:
====

First, turn on `org-edit-latex-mode`. Then you can edit a LaTeX fragment just
as what you'll do to edit a src block.

- Use `org-edit-special` to enter a dedicated LaTeX buffer.
- Use `org-edit-src-exit` to exit LaTeX buffer when you finished editing.
- Use `org-edit-src-abort` to quit editing without saving changes.

Note that all above commands are built-in Org commands, so your current
keybindings will probably do the job.