### PR TITLE
Improved output formatting

### DIFF
--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -131,27 +131,26 @@ Returns an org-link to the file."
     (ob-ipython--write-base64-string tfile b64-string)
     link))
 
-
 (defun ob-ipython--format-result (result result-type)
   "Format a RESULT from an ipython cell.
 Return RESULT-TYPE if specified. This comes from a header argument :ob-ipython-results"
-  (flet ((format-result (type value)
-          (case type
-            ('text/plain (concat value "\n"))
-            ('text/html (format
-                         "#+BEGIN_EXPORT HTML\n%s\n#+END_EXPORT\n"
-                         value))
-            ('text/latex (format
-                          "#+BEGIN_EXPORT latex\n%s\n#+END_EXPORT\n"
-                          values))
-            ('image/png (concat (ob-ipython-inline-image value) "\n"))))
-         (select-result-type (type result)
-            (if type
-                (--filter (eq (car it) (intern type)) result)
-              result)))
+  (cl-flet ((format-result (type value)
+             (case type
+               ('text/plain (concat value "\n"))
+               ('text/html (format
+                            "#+BEGIN_EXPORT HTML\n%s\n#+END_EXPORT\n"
+                            value))
+               ('text/latex (format
+                             "#+BEGIN_EXPORT latex\n%s\n#+END_EXPORT\n"
+                             values))
+               ('image/png (concat (ob-ipython-inline-image value) "\n"))))
+            (select-result-type (type result)
+               (if type
+                   (--filter (eq (car it) (intern type)) result)
+                 result)))
     (->> result
          (select-result-type result-type)
-         (-map (lambda (r) (format-result (car r) (cdr r))))
+         (--map (format-result (car it) (cdr it)))
          (apply #'concat "\n"))))
 
 ;;* A better synchronous execute function


### PR DESCRIPTION
- Specifying `result-type` will select all outputs of that type,
  not just the first one.
- Less code duplication.