### PR TITLE
Fix #89, nuke-ipython also deletes auto-generated block name

### DIFF
--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -766,7 +766,11 @@ This function is used in a C-c C-c hook to make it work like other org src block
 		  (s-starts-with? "*Python" (buffer-name buf)))
 	  (message "killing %s" buf)
 	  (kill-buffer buf)))
-  (org-babel-async-ipython-clear-queue))
+  (org-babel-async-ipython-clear-queue)
+  (save-excursion
+    (let ((el (org-element-context)))
+      (goto-char (org-element-property :begin el))
+      (delete-region (point) (1+ (point-at-eol))))))
 
 (defun debug-ipython ()
   (interactive)


### PR DESCRIPTION
The side effect is that it is now mandatory to call `nuke-ipython` in the same src block that got a problem.