### PR TITLE
split-src-block: There should be no "nil" in the begin_src line

### DIFF
--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -200,7 +200,7 @@ With a prefix BELOW move point to lower block."
     (beginning-of-line)
     (insert (format "#+END_SRC
 
-#+BEGIN_SRC %s %s\n" language parameters))
+#+BEGIN_SRC %s %s\n" language (or parameters "")))
     (beginning-of-line)
     (when (not below)
       (org-babel-previous-src-block))))


### PR DESCRIPTION
When the split src block doesn't have any parameters, there will be a nil in the begin_src line of resulting src block. This commit will fix it. 