### PR TITLE
Tweaks on async ipython

### DIFF
--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -113,6 +113,7 @@ name that is unique within the document. You might also like
 (defcustom org-babel-ipython-inline-image-dir "ipython-inline-images"
   "Directory to store ipython generated images."
   :group 'ob-ipython)
+(make-variable-buffer-local 'org-babel-ipython-inline-image-dir)
 
 ;;; Code:
 

--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -110,6 +110,10 @@ name that is unique within the document. You might also like
 `org-id-uuid'."
   :group 'ob-ipython)
 
+(defcustom org-babel-ipython-inline-image-dir "ipython-inline-images"
+  "Directory to store ipython generated images."
+  :group 'ob-ipython)
+
 ;;; Code:
 
 (add-to-list 'org-structure-template-alist
@@ -237,7 +241,7 @@ With a prefix BELOW move point to lower block."
   "Write the B64-STRING to a file.
 Returns an org-link to the file."
   (let* ((f (md5 b64-string))
-	 (d "ipython-inline-images")
+	 (d org-babel-ipython-inline-image-dir)
 	 (tfile (concat d "/ob-ipython-" f ".png"))
 	 (link (format "[[file:%s]]" tfile)))
     (unless (file-directory-p d)

--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -783,21 +783,22 @@ The name should be unique to the buffer."
 
 (defun org-babel-get-name-create ()
   "Get the name of a src block or add a name to the src block at point."
-  (if-let (name (fifth (org-babel-get-src-block-info)))
-      name
-    (save-excursion
-      (let ((el (org-element-context))
-	    (id (funcall org-babel-ipython-name-generator)))
-	(goto-char (org-element-property :begin el))
-	(insert (format "#+NAME: %s\n" id))
-	id))))
+  (let* ((elem (org-element-at-point))
+         (name (org-element-property :name elem)))
+    (or name
+        (let ((beg (org-element-property :begin elem))
+              (id (funcall org-babel-ipython-name-generator)))
+          (save-excursion
+            (goto-char beg)
+            (insert (format "#+NAME: %s\n" id)))
+          id))))
 
 
 (defun org-babel-get-session ()
   "Return current session.
 I wrote this because params returns none instead of nil. But in
 that case the process that ipython uses appears to be default."
-  (if-let (info (org-babel-get-src-block-info))
+  (if-let (info (org-babel-get-src-block-info 'light))
       (let* ((args (third info))
              (session (cdr (assoc :session args))))
         (if (and session

--- a/scimax-org.el
+++ b/scimax-org.el
@@ -412,7 +412,7 @@ fontification, as long as `org-src-fontify-natively' is non-nil."
 	      (cond
 	       ((and lang (not (string= lang "")) org-src-fontify-natively)
 		(org-src-font-lock-fontify-block lang block-start block-end)
-		(add-text-properties beg1 block-end '(src-block t)))
+		(add-text-properties beg1 block-end (list 'src-block t 'lang (substring-no-properties lang))))
 	       (quoting
 		(add-text-properties beg1 (min (point-max) (1+ end1))
 				     (let ((face-name (intern (format "org-block-%s" lang))))


### PR DESCRIPTION
Those commits includes following tweaks:
- support `:noweb` code reference
- Fixed https://github.com/jkitchin/scimax/issues/140
- Rewrite company backend, completion is now more robust.
- Replace org-babel-get-src-block-info whenever possible. That function is too heavy, causing lag to evaluation or completion. The performance is improved a lot upon this change. As I can tell, at least the completion is more responsive.
- Rework results rendering.  When `:results` is set to `output`, it will use the output as results. If no output is available, it will generate a reasonable fake output from ipython evaluation. When `:results` is set to `value`, you can use the `:ob-ipython-results` header arg to specify the result type you want. Inspired by ob-ipython, I also added a `text/org` type that can be used to format pandas dataframe as org table (tabulate.py is needed). To use it, you shoud add a ipython startup file:
```python
#!/usr/bin/env python
import IPython
from tabulate import tabulate
from pandas import Index

class OrgFormatter(IPython.core.formatters.BaseFormatter):
    def __call__(self, obj):
        try:
            if isinstance(obj, Index):
                raise Exception('Do not format Index object!')
            return tabulate(obj, headers='keys',
                            tablefmt='orgtbl', showindex='always')
        except:
            return None

ip = get_ipython()
ip.display_formatter.formatters['text/org'] = OrgFormatter()
```
- And other minor tweaks.

It is worth mentioning that setting `org-babel-ipython-debug` to `t` has a significant impact on performance of evaluation of ipython block. So I always turn it off except when I want to debug the async process.

Since I use scimax with spacemacs so you'll notice some indentation change. sorry about that.