### PR TITLE
Explicitly require scimax-org

### DIFF
--- a/scimax-org-babel-ipython.el
+++ b/scimax-org-babel-ipython.el
@@ -61,6 +61,7 @@
 
 
 (require 'ob-ipython)
+(require 'scimax-org)
 
 
 (defcustom scimax-ipython-command "jupyter"


### PR DESCRIPTION
since `org-in-ipython-block-p` depends on scimax-org