### PR TITLE
Global options, hypersetup, help and bib style

### DIFF
--- a/ox-manuscript/ox-manuscript-templates/aps-prl.org
+++ b/ox-manuscript/ox-manuscript-templates/aps-prl.org
@@ -5,7 +5,7 @@
 #+default-filename: manuscript.org
 
 #+LATEX_CLASS: revtex4-1
-#+LATEX_CLASS_OPTIONS:[aps,prl,citeautoscript,preprint,citeautoscript,showkeys,floatfix]
+#+LATEX_CLASS_OPTIONS:[aps,prl,citeautoscript,preprint,showkeys,floatfix]
 #+OPTIONS: toc:nil author:nil ^:{}
 #+EXPORT_EXCLUDE_TAGS: noexport
 #+LATEX_HEADER: \usepackage{natbib}
@@ -14,7 +14,7 @@
 #+LATEX_HEADER: \usepackage{amsmath}
 #+LATEX_HEADER: \usepackage{textcomp}
 #+LATEX_HEADER: \usepackage[version=3]{mhchem}
-#+LATEX_HEADER: \usepackage[linktocpage,pdfstartview=FitH,colorlinks,linkcolor=blue,anchorcolor=blue,citecolor=blue,filecolor=blue,menucolor=blue,urlcolor=blue]{hyperref}
+#+LATEX_HEADER: \usepackage[linktocpage,pdfstartview=FitH,colorlinks,allcolors=blue]{hyperref}
 
 \raggedbottom
 
@@ -44,11 +44,11 @@
 <replace: or delete>
 \end{acknowledgments}
 
-bibliographystyle:unsrt
+# bibliographystyle:unsrt
 bibliography:<replace: bibfile>
 
 * Help  :noexport:
 
 #+BEGIN_SRC sh
-texdoc revtex4-1
+texdoc apsguide4-1
 #+END_SRC


### PR DESCRIPTION
- One of the global options was duplicated.
- Add the shortest version of links colored.... `allcolors=blue`
- Commented the bibliography style, once the editorial (APS) and journal (PRL) are specified in the global options, the style is defined automatically.
- The correct file for APS related documentation is `apsguide4-1`, otherwise, the documentation was for IOP.