### PR TITLE
Fix pull #236 in direct buffers

### DIFF
--- a/scimax-inkscape.el
+++ b/scimax-inkscape.el
@@ -129,7 +129,7 @@ Make a new file if needed."
 
 (defun scimax-inkscape-redraw-thumbnails (&rest args)
   "Use font-lock to redraw the links."
-  (with-current-buffer (buffer-base-buffer)
+  (with-current-buffer (or (buffer-base-buffer) (current-buffer))
     (org-restart-font-lock)))
 
 ;; This gets the thumbnails to be redrawn with inline image toggling.


### PR DESCRIPTION
Just realized that my previous fix broke scimax-inkscape-redraw-thumbnails in direct buffers.