### PR TITLE
Change org-return-indent to newline-and-indent

### DIFF
--- a/scimax-org-babel-ipython-upstream.el
+++ b/scimax-org-babel-ipython-upstream.el
@@ -70,7 +70,7 @@ string to be formatted."
   :group 'ob-ipython)
 
 (defcustom ob-ipython-key-bindings
-  '(("<return>" . #'org-return-indent)
+  '(("<return>" . #'newline-and-indent)
     ("C-<return>" . #'org-ctrl-c-ctrl-c)
     ("M-<return>" . (lambda () (interactive) (scimax-execute-and-next-block t)))
     ("S-<return>" . #'scimax-execute-and-next-block)


### PR DESCRIPTION
Org return indent, according to the documentation, will call either
‘org-table-next-row’ or ‘newline-and-indent’. We can skip all org
checks and call newline-and-indent directly, since we'll never have
org-tables within an ipython src block.

In my experience this slightly reduces the latency of `<return>` within ipython src blocks. Perhaps there's something else wrong with my config, but typing <return> always lags a bit, i.e., it's not nearly as responsive as in a native python buffer.