### PR TITLE
Default scimax-org-babel-upstream render typos

### DIFF
--- a/scimax-org-babel-ipython-upstream.el
+++ b/scimax-org-babel-ipython-upstream.el
@@ -1110,6 +1110,7 @@ way, but I have left it in for compatibility."
       ;; fall-through
       (funcall
        (cdr (assoc 'default ob-ipython-mime-formatters))
+       file-or-nil
        (cdar values)))))
 
 

--- a/scimax-org-babel-ipython-upstream.el
+++ b/scimax-org-babel-ipython-upstream.el
@@ -1092,9 +1092,9 @@ FILE-OR-NIL is not used in this function."
 This is used for mime-types that don't have a formatter already
 defined. FILE-OR-NIL is not used in this function."
   (format "%s%s" (if ob-ipython-show-mime-types
-		     (format "\n# %s\n: " (caar values))
+		     (format "\n# %s\n: " (caar value))
 		   ": ")
-	  (cdar values)))
+	  (cdar value)))
 
 
 (defun ob-ipython--render (file-or-nil values)


### PR DESCRIPTION
I corrected two typos in the fall through render operations that I discovered while using scimax-org-babel-ipython-upstream.el with the Jupiter-R kernel.