### PR TITLE
fix to prevent bootstrap from failing on windows

### DIFF
--- a/bootstrap.el
+++ b/bootstrap.el
@@ -13,7 +13,8 @@
 
 (require 'gnutls)
 (when (and (string= "26" (substring emacs-version 0 2))
-	   (null gnutls-algorithm-priority))
+	   (null gnutls-algorithm-priority)
+           (not (memq system-type '(windows-nt ms-dos))))
   ;; This appears to be a bug in emacs 26 that prevents the gnu archive from being downloaded.
   ;; This solution is from https://www.reddit.com/r/emacs/comments/cdf48c/failed_to_download_gnu_archive/
   (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))


### PR DESCRIPTION
Setting gnutls-algorithm-priority to "NORMAL:-VERS-TLS1.3" causes the
following error (repeated for all archives) on windows

Failed to download ‘org’ archive.
gnutls.el: (err=[-50] The request is invalid.)
boot: (:priority NORMAL:-VERS-TLS1.3
       :hostname elpa.gnu.org
       :loglevel 0
       :min-prime-bits 256
       :trustfiles nil
       :crlfiles nil
       :keylist nil
       :verify-flags nil
       :verify-error nil
       :callbacks nil)

Windows is able to retrieve files correctly when gnutls-algorithm-priority is null.


I'm not entirely sure why I am encountering these issues on windows now, and did not encounter them in the past, I have encountered this on two windows systems running windows 10 and emacs 26.3.
