### PR TITLE
added eval-and-compile of helm-source

### DIFF
--- a/org-db.el
+++ b/org-db.el
@@ -6,6 +6,7 @@
 (require 's)    ; for s-trim
 (require 'org)
 (use-package emacsql-sqlite)
+(eval-and-compile 'helm-source)  ; for helm-build-sync-source
 
 
 ;;; Code:


### PR DESCRIPTION
This is to allow `orb-db.el` to work when it is included in my own private package which is byte-compiled.
Without the added `eval-and-compile`, I keep getting the following error:

```
org-db-open-heading: Invalid function: helm-build-sync-source
```

This error I think arises from the fact that when `org-db.el` was byte-compiled, `helm-source` was not loaded and so `helm-build-sync-source` macro was not defined.