### PR TITLE
added eval-and-compile to prepare for byte-compiling

### DIFF
--- a/org-db.el
+++ b/org-db.el
@@ -6,6 +6,7 @@
 (require 's)    ; for s-trim
 (require 'org)
 (use-package emacsql-sqlite)
+(eval-and-compile (require 'helm-source))  ; for helm-build-sync-source
 
 
 ;;; Code:

--- a/org-db.el
+++ b/org-db.el
@@ -617,6 +617,7 @@ Optional RECURSIVE is non-nil find files recursively."
 			     :begin begin)))))
     candidates))
 
+;;;###autoload
 (defun org-db-open-heading ()
   "Use helm to select and open a heading."
   (interactive)


### PR DESCRIPTION
Byte-compiled org-db.el fails to work today, because `helm-build-sync-source` macro is used, but there is no `(require 'helm-source)` to define it.   This is fixed by adding one `eval-and-compile`.  Also one autoload cookie is added.