### PR TITLE
Change swiper binding to remap

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -84,7 +84,7 @@
 
 (use-package swiper
   :bind
-  ("C-s" . counsel-grep-or-swiper)
+  ([remap isearch-forward] . counsel-grep-or-swiper)
   ("H-s" . swiper-all)
   :diminish ivy-mode
   :config


### PR DESCRIPTION
The best practice is to use a remap for replacing existing bindings with similar functionality. This is really useful for users of non-default keybindings. I have a package with custom keybindings and users can't get swiper to work with it. With a remap this works fine. 