### PR TITLE
following evil-collection README

### DIFF
--- a/scimax-evil.el
+++ b/scimax-evil.el
@@ -8,22 +8,29 @@
 (use-package evil
   :ensure t
   :init
-  (setq evil-want-integration nil)
+  (setq evil-want-integration t) ;; This is optional since it's already set to t by default.
+  (setq evil-want-keybinding nil)
   :config
   (evil-mode 1))
 
-(use-package evil-collection)
-(use-package general
+(use-package evil-collection
+  :after evil
   :ensure t
   :config
-  (setq general-override-states '(emacs
-				  hybrid
-				  normal
-				  visual
-				  motion
-				  operator
-				  replace))
-  (general-override-mode)
+  (evil-collection-init))
+
+(use-package general
+  :ensure t
+  :init
+  (setq general-override-states '(insert
+                                  emacs
+                                  hybrid
+                                  normal
+                                  visual
+                                  motion
+                                  operator
+                                  replace))
+  :config
   (general-define-key
    :states '(normal visual motion)
    :keymaps 'override


### PR DESCRIPTION
when I `(require 'scimax-evil)` in my `user.el` I see emacs-evil/evil-collection#60:
```
Warning (evil-collection): Make sure to set `evil-want-keybinding' to nil before loading evil or evil-collection.
See https://github.com/emacs-evil/evil-collection/issues/60 for more details
```
then I followed
https://github.com/emacs-evil/evil-collection#faq
https://github.com/emacs-evil/evil-collection#installation