### PR TITLE
updated ox-manuscript to use revtex4-2

### DIFF
--- a/ox-manuscript/ox-manuscript-templates/aps-prb.org
+++ b/ox-manuscript/ox-manuscript-templates/aps-prb.org
@@ -4,7 +4,7 @@
 #+contributor: John Kitchin <jkitchin@andrew.cmu.edu>
 #+default-filename: manuscript.org
 
-#+LATEX_CLASS: revtex4-1
+#+LATEX_CLASS: revtex4-2
 #+LATEX_CLASS_OPTIONS: [aps,prb,citeautoscript,preprint,citeautoscript,showkeys,linenumbers]
 #+OPTIONS: toc:nil ^:{} author:nil
 #+EXPORT_EXCLUDE_TAGS: noexport

--- a/ox-manuscript/ox-manuscript-templates/aps-prl.org
+++ b/ox-manuscript/ox-manuscript-templates/aps-prl.org
@@ -4,7 +4,7 @@
 #+contributor: John Kitchin <jkitchin@andrew.cmu.edu>
 #+default-filename: manuscript.org
 
-#+LATEX_CLASS: revtex4-1
+#+LATEX_CLASS: revtex4-2
 #+LATEX_CLASS_OPTIONS:[aps,prl,citeautoscript,preprint,showkeys,floatfix]
 #+OPTIONS: toc:nil author:nil ^:{}
 #+EXPORT_EXCLUDE_TAGS: noexport

--- a/ox-manuscript/ox-manuscript.el
+++ b/ox-manuscript/ox-manuscript.el
@@ -96,8 +96,8 @@ if you should continue to the next step."
 	       ("\\subparagraph{%s}" . "\\subparagraph*{%s}")))
 
 ;; ** <<APS journals>>
-(add-to-list 'org-latex-classes '("revtex4-1"
-				  "\\documentclass{revtex4-1}
+(add-to-list 'org-latex-classes '("revtex4-2"
+				  "\\documentclass{revtex4-2}
  [NO-DEFAULT-PACKAGES]
  [PACKAGES]
  [EXTRA]"


### PR DESCRIPTION
The latest version of RevTeX is 4-2. The existing files in ox-manuscript that use revtex4-1 are incompatible with this. I've updated the files to work with the latest version of revtex.