### PR TITLE
Spelling

### DIFF
--- a/deprecated/bookmark+-1.el
+++ b/deprecated/bookmark+-1.el
@@ -6180,7 +6180,7 @@ If it is a record then it need not belong to `bookmark-alist'."
 
 (defun bmkp-url-bookmark-p (bookmark)
   "Return non-nil if BOOKMARK is a URL bookmark.
-This means that it satifies `bmkp-eww-bookmark-p' (Emacs 25+),
+This means that it satisfies `bmkp-eww-bookmark-p' (Emacs 25+),
 `bmkp-w3m-bookmark-p', or `bmkp-url-browse-bookmark-p'.
 
 BOOKMARK is a bookmark name or a bookmark record.

--- a/deprecated/bookmark+-1.el
+++ b/deprecated/bookmark+-1.el
@@ -954,7 +954,7 @@ The possible values:
 (defcustom bmkp-auto-idle-bookmark-min-distance 1000
   "*Minimum number of chars between automatic bookmark positions."
   :type '(choice
-          (const   :tag "No minumum distance" nil)
+          (const   :tag "No minimum distance" nil)
           (integer :tag "At least this many chars" :value 1000))
   :group 'bookmark-plus)
 

--- a/deprecated/bookmark+-1.el
+++ b/deprecated/bookmark+-1.el
@@ -4252,7 +4252,7 @@ When you finish editing, use \\<bmkp-edit-bookmark-record-mode-map>\
 (define-key bmkp-edit-bookmark-records-mode-map "\C-c\C-c" 'bmkp-edit-bookmark-records-send)
 
 (defvar bmkp-edit-bookmark-records-number 0
-  "NUmber of bookmard records being edited.")
+  "NUmber of bookmark records being edited.")
 
 ;;;###autoload (autoload 'bmkp-edit-bookmark-records-send "bookmark+")
 (defun bmkp-edit-bookmark-records-send (&optional msg-p) ; Bound to `C-c C-c' in records-editing buffer.

--- a/deprecated/bookmark+-1.el
+++ b/deprecated/bookmark+-1.el
@@ -7081,7 +7081,7 @@ Return the copy.
 Do not sort if `bmkp-sort-comparer' is nil.
 This is a non-destructive operation: ALIST is not modified.
 
-Sorting is done using using `bmkp-sort-comparer'.
+Sorting is done using `bmkp-sort-comparer'.
 If `bmkp-reverse-sort-p' is non-nil, then reverse the sort order.
 Keys are compared for sorting using `equal'.
 
@@ -7114,7 +7114,7 @@ elements with keys in list OMIT."
 ;;; Always remove duplicates.  Keep only the first element with a given
 ;;; key.  This is a non-destructive operation: ALIST is not modified.
 
-;;; Sorting is done using using `bmkp-sort-comparer'.
+;;; Sorting is done using `bmkp-sort-comparer'.
 ;;; If `bmkp-reverse-sort-p' is non-nil, then reverse the sort order.
 ;;; Keys are compared for sorting using `equal'.
 ;;; If optional arg OMIT is non-nil, then omit from the return value any

--- a/deprecated/bookmark+-1.el
+++ b/deprecated/bookmark+-1.el
@@ -9936,7 +9936,7 @@ BOOKMARK is a bookmark name or a bookmark record."
     (let ((buf       (bmkp-get-buffer-name bookmark))
           (kbd-macs  (bookmark-prop-get bookmark 'kmacros)))
       (unless (and buf  (get-buffer buf))
-        (message "Bookmarked for non-existent buffer `%s', so using current buffer" buf) (sit-for 3)
+        (message "Bookmarked for nonexistent buffer `%s', so using current buffer" buf) (sit-for 3)
         (setq buf (current-buffer)))
       (with-current-buffer buf
         (let ((kmacs  kbd-macs))
@@ -9957,7 +9957,7 @@ BOOKMARK is a bookmark name or a bookmark record."
   (let ((buf        (bmkp-get-buffer-name bookmark))
         (vars+vals  (bookmark-prop-get bookmark 'variables)))
     (unless (get-buffer buf)
-      (message "Bookmarked for non-existent buffer `%s', so using current buffer" buf) (sit-for 3)
+      (message "Bookmarked for nonexistent buffer `%s', so using current buffer" buf) (sit-for 3)
       (setq buf (current-buffer)))
     (with-current-buffer buf
       (dolist (var+val  vars+vals)

--- a/deprecated/bookmark+-1.el
+++ b/deprecated/bookmark+-1.el
@@ -382,7 +382,7 @@
 ;;    `bmkp-region-jump-other-window', `bmkp-remote-file-jump',
 ;;    `bmkp-remote-file-jump-other-window',
 ;;    `bmkp-remote-non-dir-file-jump',
-;;    `bmkp-temote-non-dir-file-jump-other-window',
+;;    `bmkp-remote-non-dir-file-jump-other-window',
 ;;    `bmkp-remove-all-tags', `bmkp-remove-tags',
 ;;    `bmkp-remove-tags-from-all', `bmkp-rename-tag',
 ;;    `bmkp-retrieve-icicle-search-hits',

--- a/deprecated/bookmark+-bmu.el
+++ b/deprecated/bookmark+-bmu.el
@@ -2496,7 +2496,7 @@ From Lisp, non-nil optional arg MSG-P means show progress messages."
     (bmkp-bmenu-cancel-incremental-filtering)))
 
 (defun bmkp-bmenu-filter-alist-by-annotation-regexp ()
-  "Filter bookmarks by annoation, then refresh the bookmark list."
+  "Filter bookmarks by annotation, then refresh the bookmark list."
   (setq bmkp-bmenu-filter-function  'bmkp-regexp-filtered-annotation-alist-only
         bmkp-bmenu-title            (format "Bookmarks with Annotations Matching Regexp `%s'"
                                             bmkp-bmenu-filter-pattern))

--- a/deprecated/bookmark+-bmu.el
+++ b/deprecated/bookmark+-bmu.el
@@ -5241,7 +5241,7 @@ compare them by bookmark name.")
 Sort a bookmark accessed more recently before one accessed less
 recently or not accessed.  Sort a bookmark to an existing buffer
 before a local file bookmark.  When two bookmarks are not comparable
-by such critera, sort them by bookmark name.  (In particular, sort
+by such criteria, sort them by bookmark name.  (In particular, sort
 remote-file bookmarks by bookmark name.")
 
 (bmkp-define-sort-command               ; Bound to `s v' in bookmark list

--- a/deprecated/bookmark+-bmu.el
+++ b/deprecated/bookmark+-bmu.el
@@ -5657,7 +5657,7 @@ are marked or ALLP is non-nil."
 
 ;;; `Bookmark+' menu-bar menu in `*Bookmark List*'
 
-(defvar bmkp-bmenu-menubar-menu (make-sparse-keymap "Bookmark+") "`Boomark+' menu-bar menu.")
+(defvar bmkp-bmenu-menubar-menu (make-sparse-keymap "Bookmark+") "`Bookmark+' menu-bar menu.")
 (define-key bookmark-bmenu-mode-map [menu-bar bmkp]
   (cons "Bookmark+" bmkp-bmenu-menubar-menu))
 

--- a/deprecated/bookmark+-chg.el
+++ b/deprecated/bookmark+-chg.el
@@ -664,7 +664,7 @@
 ;;     bmkp-remove-all-tags, bmkp(-autofile)-(add|remove)-tags, bmkp-set-tag-value,
 ;;       bmkp-paste-(add|replace)-tags, bmkp-(url|file)-target-set, bmkp-autofile-set:
 ;;         Added missing NO-UPDATE-P arg for interactive spec.
-;;     bmkp-remove-all-tags: Moveed msg to the end.
+;;     bmkp-remove-all-tags: Moved msg to the end.
 ;;     bmkp-paste-replace-tags: Added sleep-for after first msg.
 ;; 2012/11/13 dadams
 ;;     bmkp-sorting-description: Fixed 1st case: use ORDER only if bmkp-sort-comparer is also non-nil.

--- a/deprecated/bookmark+-chg.el
+++ b/deprecated/bookmark+-chg.el
@@ -2452,7 +2452,7 @@
 ;; 2010/06/11 dadams
 ;;     Wrap all (require '* nil t) in condition-case.
 ;; 2010/06/07 dadams
-;;     Fix deskstop bookmarks for Emacs < 22.  Protect:
+;;     Fix desktop bookmarks for Emacs < 22.  Protect:
 ;;       *-release-lock with fboundp, *-buffer-args-list with boundp, *-dir with Emacs version #,
 ;; 2010/05/30 dadams
 ;;     Added: bookmarkp-(next|previous)-bookmark-w32(-repeat).  Bound to C-x p (next|prior).

--- a/deprecated/bookmark+-chg.el
+++ b/deprecated/bookmark+-chg.el
@@ -3329,7 +3329,7 @@
 ;;                  Faces for menu list.  Change region color.
 ;;       2009-06-11 Add: *-region-search-size, *-get-buffername, *-use-region.
 ;;                  Redefine *-handle-bookmark, *-jump, to fit bookmark-use-region.
-;;                  Add condtions to bookmark-make-record.  Support w3m.  Support t command.
+;;                  Add conditions to bookmark-make-record.  Support w3m.  Support t command.
 ;;       2009-06-10 Fix search regexp.  Fix region in Info. Save bookmark if region moves.
 ;;       2009-06-09 Added: bookmark-make-record(-region), bookmark-region-handler.
 ;;                  Relocation.

--- a/deprecated/bookmark+-doc.el
+++ b/deprecated/bookmark+-doc.el
@@ -3472,7 +3472,7 @@
 ;;  You can delete all such temporary bookmarks from the current
 ;;  bookmark list using command `bmkp-delete-all-temporary-bookmarks'
 ;;  (or by using `X M' to mark them in the bookmark-list display and
-;;  then hitting `D' to delete thems).
+;;  then hitting `D' to delete them).
 ;;
 ;;  In the bookmark-list display (buffer `*Bookmark List*'), temporary
 ;;  bookmarks are indicated with the mark `X' in the same column where

--- a/deprecated/bookmark+-doc.el
+++ b/deprecated/bookmark+-doc.el
@@ -839,7 +839,7 @@
 ;;  (see (@> "Bookmarks for Specific Files or Buffers")).
 ;;
 ;;  All bookmark jump commands are bound to keys that have the prefix
-;;  `C-x j'.  There is an other-window version of most jump commands,
+;;  `C-x j'.  There is an `other-window` version of most jump commands,
 ;;  and it is bound to the same key as the same-window command, except
 ;;  the prefix is `C-x 4 j', not `C-x j'.  For instance,
 ;;  `bmkp-dired-jump-other-window' is bound to `C-x 4 j d'.

--- a/deprecated/bookmark+-doc.el
+++ b/deprecated/bookmark+-doc.el
@@ -1196,7 +1196,7 @@
 ;;    T v bmkp-jump RET (lambda () (message "Hello!"))
 ;;
 ;;  The function that is the value of a "bmkp-jump" tag is called just
-;;  after the the standard hook `bookmark-after-jump-hook' is invoked.
+;;  after the standard hook `bookmark-after-jump-hook' is invoked.
 ;;  You can use this tag to invoke functions that are specific to
 ;;  individual bookmarks; bookmarks can thus have their own, extra
 ;;  jump functions.
@@ -3071,7 +3071,7 @@
 ;;    then the bookmarks in the current file or buffer are used as the
 ;;    navlist.
 ;;
-;;  * Otherwise, a snapshot is taken of the the bookmarks currently in
+;;  * Otherwise, a snapshot is taken of the bookmarks currently in
 ;;    the global bookmark list (the value of variable
 ;;    `bookmark-alist') as the navlist.
 ;;
@@ -3664,7 +3664,7 @@
 ;;  the text in the buffer, the highlighted location can thus become
 ;;  out of sync with the recorded position.  This is normal.  When you
 ;;  jump to the bookmark, its highlight is automatically repositioned
-;;  to the recorded location, possibly adjusted according to the the
+;;  to the recorded location, possibly adjusted according to the
 ;;  surrounding context.
 ;;
 ;;  In addition to the default highlighting, which you can customize,

--- a/deprecated/bookmark+-doc.el
+++ b/deprecated/bookmark+-doc.el
@@ -854,7 +854,7 @@
 ;;  `bmkp-jump-map-prefix-keys' and
 ;;  `bmkp-jump-other-window-map-prefix-keys'.
 ;;
-;;  If you do not remember the different type-specfic bindings, you
+;;  If you do not remember the different type-specific bindings, you
 ;;  can use commands `bmkp-jump-to-type' and
 ;;  `bmkp-jump-to-type-other-window' (`C-x j :' and `C-x 4 j :').
 ;;  They work for any type, prompting you first for the type, then for

--- a/deprecated/bookmark+-doc.el
+++ b/deprecated/bookmark+-doc.el
@@ -387,7 +387,7 @@
 ;;     - Lisp variable bookmarks.  A bookmark can represent a set of
 ;;       variables and their values.
 ;;
-;;     - Snippet bookmarks.  Select some some text and give it a
+;;     - Snippet bookmarks.  Select some text and give it a
 ;;       (bookmark) name.  Then copy it to the `kill-ring' anytime, in
 ;;       any Emacs session.
 ;;

--- a/deprecated/bookmark+-lit.el
+++ b/deprecated/bookmark+-lit.el
@@ -869,7 +869,7 @@ With a prefix arg you are prompted for the style and/or face to use:
  Plain prefix arg (`C-u'): prompt for both style and face.
  Numeric non-negative arg: prompt for face.
  Numeric negative arg: prompt for style.
-See `bmkp-light-boookmark' for argument descriptions."
+See `bmkp-light-bookmark' for argument descriptions."
   (interactive
    (let* ((bmk  (bookmark-completing-read "Highlight bookmark" nil (bmkp-this-buffer-alist-only)))
           (sty  (and current-prefix-arg  (or (consp current-prefix-arg)

--- a/deprecated/bookmark+1.el
+++ b/deprecated/bookmark+1.el
@@ -6180,7 +6180,7 @@ If it is a record then it need not belong to `bookmark-alist'."
 
 (defun bmkp-url-bookmark-p (bookmark)
   "Return non-nil if BOOKMARK is a URL bookmark.
-This means that it satifies `bmkp-eww-bookmark-p' (Emacs 25+),
+This means that it satisfies `bmkp-eww-bookmark-p' (Emacs 25+),
 `bmkp-w3m-bookmark-p', or `bmkp-url-browse-bookmark-p'.
 
 BOOKMARK is a bookmark name or a bookmark record.

--- a/deprecated/bookmark+1.el
+++ b/deprecated/bookmark+1.el
@@ -954,7 +954,7 @@ The possible values:
 (defcustom bmkp-auto-idle-bookmark-min-distance 1000
   "*Minimum number of chars between automatic bookmark positions."
   :type '(choice
-          (const   :tag "No minumum distance" nil)
+          (const   :tag "No minimum distance" nil)
           (integer :tag "At least this many chars" :value 1000))
   :group 'bookmark-plus)
 

--- a/deprecated/bookmark+1.el
+++ b/deprecated/bookmark+1.el
@@ -4252,7 +4252,7 @@ When you finish editing, use \\<bmkp-edit-bookmark-record-mode-map>\
 (define-key bmkp-edit-bookmark-records-mode-map "\C-c\C-c" 'bmkp-edit-bookmark-records-send)
 
 (defvar bmkp-edit-bookmark-records-number 0
-  "NUmber of bookmard records being edited.")
+  "NUmber of bookmark records being edited.")
 
 ;;;###autoload (autoload 'bmkp-edit-bookmark-records-send "bookmark+")
 (defun bmkp-edit-bookmark-records-send (&optional msg-p) ; Bound to `C-c C-c' in records-editing buffer.

--- a/deprecated/bookmark+1.el
+++ b/deprecated/bookmark+1.el
@@ -7081,7 +7081,7 @@ Return the copy.
 Do not sort if `bmkp-sort-comparer' is nil.
 This is a non-destructive operation: ALIST is not modified.
 
-Sorting is done using using `bmkp-sort-comparer'.
+Sorting is done using `bmkp-sort-comparer'.
 If `bmkp-reverse-sort-p' is non-nil, then reverse the sort order.
 Keys are compared for sorting using `equal'.
 
@@ -7114,7 +7114,7 @@ elements with keys in list OMIT."
 ;;; Always remove duplicates.  Keep only the first element with a given
 ;;; key.  This is a non-destructive operation: ALIST is not modified.
 
-;;; Sorting is done using using `bmkp-sort-comparer'.
+;;; Sorting is done using `bmkp-sort-comparer'.
 ;;; If `bmkp-reverse-sort-p' is non-nil, then reverse the sort order.
 ;;; Keys are compared for sorting using `equal'.
 ;;; If optional arg OMIT is non-nil, then omit from the return value any

--- a/deprecated/bookmark+1.el
+++ b/deprecated/bookmark+1.el
@@ -9936,7 +9936,7 @@ BOOKMARK is a bookmark name or a bookmark record."
     (let ((buf       (bmkp-get-buffer-name bookmark))
           (kbd-macs  (bookmark-prop-get bookmark 'kmacros)))
       (unless (and buf  (get-buffer buf))
-        (message "Bookmarked for non-existent buffer `%s', so using current buffer" buf) (sit-for 3)
+        (message "Bookmarked for nonexistent buffer `%s', so using current buffer" buf) (sit-for 3)
         (setq buf (current-buffer)))
       (with-current-buffer buf
         (let ((kmacs  kbd-macs))
@@ -9957,7 +9957,7 @@ BOOKMARK is a bookmark name or a bookmark record."
   (let ((buf        (bmkp-get-buffer-name bookmark))
         (vars+vals  (bookmark-prop-get bookmark 'variables)))
     (unless (get-buffer buf)
-      (message "Bookmarked for non-existent buffer `%s', so using current buffer" buf) (sit-for 3)
+      (message "Bookmarked for nonexistent buffer `%s', so using current buffer" buf) (sit-for 3)
       (setq buf (current-buffer)))
     (with-current-buffer buf
       (dolist (var+val  vars+vals)

--- a/deprecated/bookmark+1.el
+++ b/deprecated/bookmark+1.el
@@ -382,7 +382,7 @@
 ;;    `bmkp-region-jump-other-window', `bmkp-remote-file-jump',
 ;;    `bmkp-remote-file-jump-other-window',
 ;;    `bmkp-remote-non-dir-file-jump',
-;;    `bmkp-temote-non-dir-file-jump-other-window',
+;;    `bmkp-remote-non-dir-file-jump-other-window',
 ;;    `bmkp-remove-all-tags', `bmkp-remove-tags',
 ;;    `bmkp-remove-tags-from-all', `bmkp-rename-tag',
 ;;    `bmkp-retrieve-icicle-search-hits',

--- a/deprecated/ox-rtf.el
+++ b/deprecated/ox-rtf.el
@@ -6,7 +6,7 @@
 ;; for RTF see http://www.biblioscape.com/rtf15_spec.htm
 ;; and https://www.safaribooksonline.com/library/view/rtf-pocket-guide/9781449302047/ch01.html
 ;;
-;; It isn't my intention to full support RTF export to arbitrily complex
+;; It isn't my intention to full support RTF export to arbitrarily complex
 ;; documents, although I would like to get to where citations as footnotes are
 ;; reasonable, and cross-references work.
 

--- a/deprecated/scimax-org-babel-ipython.el
+++ b/deprecated/scimax-org-babel-ipython.el
@@ -182,7 +182,7 @@ With prefix arg BELOW, insert it below the current point."
       (forward-line -3)))
 
    ((org-in-src-block-p)
-    ;; goto begining and insert
+    ;; goto beginning and insert
     (goto-char (org-element-property :begin (org-element-context)))
     (insert "\n#+BEGIN_SRC ipython
 

--- a/deprecated/scimax-org-babel-ipython.el
+++ b/deprecated/scimax-org-babel-ipython.el
@@ -15,7 +15,7 @@
 ;; Customization variables
 ;;
 ;; If `org-babel-async-ipython' is non-nil the src blocks will be run
-;; asynchrounously allowing you to work in emacs while the code runs. This mode
+;; asynchronously allowing you to work in emacs while the code runs. This mode
 ;; will create names for each code-block if they don't already have a name,
 ;; defaulting to a human readable name. The number of words in the name is
 ;; defined by `org-babel-ipython-name-length'. The function used to generate the

--- a/emacs-keybinding-command-tooltip-mode.el
+++ b/emacs-keybinding-command-tooltip-mode.el
@@ -100,7 +100,7 @@ commands and variables."
 			 ;; prevent the window from opening, and to eliminate
 			 ;; the minibuffer message.
 			 (describe-variable (intern command))
-		       ;; clear minbuffer
+		       ;; clear minibuffer
 		       (message ""))))))
 	   (describe-func
 	    `(lambda ()

--- a/help-fns+.el
+++ b/help-fns+.el
@@ -762,7 +762,7 @@ Optional arg NOMSG non-nil means do not display a progress message."
   (defun Info-first-index-occurrence (index-entry &optional index-nodes manuals nomsg)
     "Return nil or an occurrence of INDEX-ENTRY in INDEX-NODES of MANUALS.
 Search INDEX-NODES and MANUALS in order.
-A non-nil return value is the first first successful index lookup, in
+A non-nil return value is the first successful index lookup, in
 the form (FILE INDEX-ENTRY NODE LINE) - see `Info-index-occurrences'.
 
 Optional arg INDEX-NODES are the index nodes of MANUALS to search.

--- a/help-fns+.el
+++ b/help-fns+.el
@@ -109,7 +109,7 @@
 ;;    (require 'help-fns+)
 ;;
 ;;  Acknowledgement: Passing text properties on doc strings to the
-;;  *Help* buffer is an idea from Johan bockgard.  He sent it on
+;;  *Help* buffer is an idea from Johan Bockgard.  He sent it on
 ;;  2007-01-24 to emacs-devel@gnu.org, Subject
 ;;  "display-completion-list should not strip text properties".
 ;;

--- a/kitchingroup/kitchingroup.el
+++ b/kitchingroup/kitchingroup.el
@@ -29,7 +29,7 @@ Usually at ~/Box/andrewid."
 
 
 (defcustom kitchingroup-github-id nil
-  "Your Github id.
+  "Your GitHub id.
 This should be defined in user/preload.el, e.g. (setq kitchingroup-github-id \"your-id\")"
   :group 'kitchingroup)
 

--- a/ore.el
+++ b/ore.el
@@ -216,7 +216,7 @@ Info node `(org) Tables'.
 
 
 (defun ore-plain-list (element)
-  "`ore' doucmentation for plain lists."
+  "`ore' documentation for plain lists."
   (concat
    (substitute-command-keys
     "You are on a plain list.

--- a/org-mac-link.el
+++ b/org-mac-link.el
@@ -324,7 +324,7 @@ The links are of the form <link>::split::<name>."
 ;; the contents of the url bar, and copy it. It then uses the title of
 ;; the window as the text of the link. There is no way to grab links
 ;; from other open tabs, and further, if there is more than one window
-;; open, it is not clear which one will be used (though emperically it
+;; open, it is not clear which one will be used (though empirically it
 ;; seems that it is always the last active window).
 
 (defun org-as-mac-firefox-get-frontmost-url ()

--- a/org-mac-link.el
+++ b/org-mac-link.el
@@ -49,7 +49,7 @@
 ;;; Commentary:
 ;;
 ;; This code allows you to grab either the current selected items, or
-;; the frontmost url in various mac appliations, and insert them as
+;; the frontmost url in various mac applications, and insert them as
 ;; hyperlinks into the current org-mode document at point.
 ;;
 ;; This code is heavily based on, and indeed incorporates,

--- a/org-show/org-show.el
+++ b/org-show/org-show.el
@@ -394,7 +394,7 @@ Try to reset the state of your Emacs. It isn't perfect ;)"
 
 (defun org-show-increase-text-size (&optional arg)
   "Increase text size. Bound to \\[org-show-increase-text-size].
-With prefix ARG, set `org-show-text-scale' so subsquent slides
+With prefix ARG, set `org-show-text-scale' so subsequent slides
 are the same text size."
   (interactive "P")
   (text-scale-increase 1.5)
@@ -404,7 +404,7 @@ are the same text size."
 
 (defun org-show-decrease-text-size (&optional arg)
   "Increase text size. Bound to \\[org-show-decrease-text-size].
-With prefix ARG, set `org-show-text-scale' so subsquent slides
+With prefix ARG, set `org-show-text-scale' so subsequent slides
 are the same text size."
   (interactive "P")
   (text-scale-decrease 1.5)

--- a/ox-cmu/ox-cmu-dissertation.el
+++ b/ox-cmu/ox-cmu-dissertation.el
@@ -199,7 +199,7 @@ contents of hidden elements.
 
 When optional argument BODY-ONLY is non-nil, only write content.
 
-EXT-PLIST, when provided, is a proeprty list with external
+EXT-PLIST, when provided, is a property list with external
 parameters overriding Org default settings, but still inferior to
 file-local settings.
 

--- a/ox-cmu/ox-cmu-memo.el
+++ b/ox-cmu/ox-cmu-memo.el
@@ -122,7 +122,7 @@ contents of hidden elements.
 
 When optional argument BODY-ONLY is non-nil, only write content.
 
-EXT-PLIST, when provided, is a proeprty list with external
+EXT-PLIST, when provided, is a property list with external
 parameters overriding Org default settings, but still inferior to
 file-local settings.
 

--- a/ox-cmu/ox-cmu-ms-report.el
+++ b/ox-cmu/ox-cmu-ms-report.el
@@ -153,7 +153,7 @@ contents of hidden elements.
 
 When optional argument BODY-ONLY is non-nil, only write content.
 
-EXT-PLIST, when provided, is a proeprty list with external
+EXT-PLIST, when provided, is a property list with external
 parameters overriding Org default settings, but still inferior to
 file-local settings.
 

--- a/ox-manuscript/ox-manuscript-templates/nsf-biosketch.org
+++ b/ox-manuscript/ox-manuscript-templates/nsf-biosketch.org
@@ -199,33 +199,33 @@ Assuming you have a bibtex file that is up to date, you can extract the authors 
 
 
 #+tblname: graduate-students
-| Firstname | Lastname     | year | degree | affiliation       |
-|-----------+--------------+------+--------+-------------------|
-| Sneha     | Akhade       | 2011 | MS     | Penn State        |
-| Rich      | Alesi        | 2012 | PhD    | Intel             |
-| Robin     | Chao         | 2012 | PhD    | IBM               |
-| Mehak     | Chawla       | 2015 | MS     | Dubai             |
-| Jing      | Chou         | 2007 | MS     | Taiwan            |
-| Matt      | Curnan       | 2015 | PhD    | unknown           |
-| Frank     | DeCarlo      | 2010 | MS     | ERC               |
-| Ethan     | Demeter      | 2013 | PhD    | FuelCell          |
-| Siddhard  | Deshpande    | 2015 | MS     | CMU               |
-| Zhizhong  | Ding         | 2012 | MS     | Lousiana State U. |
-| Qingqi    | Fan          | 2014 | MS     | unknown           |
-| Nitish    | Govindarajan | 2014 | MS     | unknown           |
-| Steve     | Illes        | 2014 | MS     | 3M                |
-| Nilay     | Inoglu       | 2011 | PhD    | Exxon             |
-| James     | Landon       | 2011 | PhD    | CAER              |
-| Anita     | Lee          | 2013 | PhD    | Exxon             |
-| Yuan      | Li           | 2008 | PD     | Taiwan            |
-| Bin       | Liu          | 2013 | PD     | Kansas State U.   |
-| Meiheng   | Lu           | 2014 | MS     | unknown           |
-| Prateek   | Mehta        | 2013 | MS     | Notre Dame        |
-| Spencer   | Miller       | 2011 | PhD    | Combinatorics     |
-| Venkatesh | Naik         | 2015 | MS     | unknown           |
-| Hari      | Thirumalai   | 2015 | MS     | U. Houston        |
-| Vivek     | Vinodan      | 2012 | MS     | unknown           |
-| Wenqin    | You          | 2014 | MS     | CMU               |
+| Firstname | Lastname     | year | degree | affiliation        |
+|-----------+--------------+------+--------+--------------------|
+| Sneha     | Akhade       | 2011 | MS     | Penn State         |
+| Rich      | Alesi        | 2012 | PhD    | Intel              |
+| Robin     | Chao         | 2012 | PhD    | IBM                |
+| Mehak     | Chawla       | 2015 | MS     | Dubai              |
+| Jing      | Chou         | 2007 | MS     | Taiwan             |
+| Matt      | Curnan       | 2015 | PhD    | unknown            |
+| Frank     | DeCarlo      | 2010 | MS     | ERC                |
+| Ethan     | Demeter      | 2013 | PhD    | FuelCell           |
+| Siddhard  | Deshpande    | 2015 | MS     | CMU                |
+| Zhizhong  | Ding         | 2012 | MS     | Louisiana State U. |
+| Qingqi    | Fan          | 2014 | MS     | unknown            |
+| Nitish    | Govindarajan | 2014 | MS     | unknown            |
+| Steve     | Illes        | 2014 | MS     | 3M                 |
+| Nilay     | Inoglu       | 2011 | PhD    | Exxon              |
+| James     | Landon       | 2011 | PhD    | CAER               |
+| Anita     | Lee          | 2013 | PhD    | Exxon              |
+| Yuan      | Li           | 2008 | PD     | Taiwan             |
+| Bin       | Liu          | 2013 | PD     | Kansas State U.    |
+| Meiheng   | Lu           | 2014 | MS     | unknown            |
+| Prateek   | Mehta        | 2013 | MS     | Notre Dame         |
+| Spencer   | Miller       | 2011 | PhD    | Combinatorics      |
+| Venkatesh | Naik         | 2015 | MS     | unknown            |
+| Hari      | Thirumalai   | 2015 | MS     | U. Houston         |
+| Vivek     | Vinodan      | 2012 | MS     | unknown            |
+| Wenqin    | You          | 2014 | MS     | CMU                |
 
 
 

--- a/ox-manuscript/ox-manuscript-templates/wiley-ijqc.org
+++ b/ox-manuscript/ox-manuscript-templates/wiley-ijqc.org
@@ -34,7 +34,7 @@
 
 #+latex_header: \author[1]{<replace with name>}
 #+latex_header: \author[2]{<replace with name>}
-#+latex_header: \author[2]{<replace with correspinding name>\thanks{<replace with email>}}
+#+latex_header: \author[2]{<replace with corresponding name>\thanks{<replace with email>}}
 #+latex_header: \affil[1]{<replace with address>}
 #+latex_header: \affil[2]{<replace with address>}
 

--- a/scimax-autoformat-abbrev.el
+++ b/scimax-autoformat-abbrev.el
@@ -50,7 +50,7 @@
 
 ;; This module also sets up flyspell to save abbrevs so they autocorrect in the
 ;; future. The variable `scimax-save-spellcheck-abbrevs' defaults to t, and
-;; saves any workd you correct with flyspell as an abbrev. It also binds C-x C-i
+;; saves any work you correct with flyspell as an abbrev. It also binds C-x C-i
 ;; to a function that calls ispell on a word, and then creates an abbrev for the
 ;; selection you make.
 ;;

--- a/scimax-contacts.el
+++ b/scimax-contacts.el
@@ -342,7 +342,7 @@ Optional argument PATH is ignored."
 
 
 ;; * Capture contacts in messages
-;; I use this this mu4e, but it should work in any message.
+;; I use this with mu4e, but it should work in any message.
 
 (defun scimax-message-get-emails ()
   "Captures emails in a message."

--- a/scimax-contacts.el
+++ b/scimax-contacts.el
@@ -78,7 +78,7 @@ If you are in a contact heading we store a link."
 
 (defun scimax-contact-complete (&optional arg)
   "Completion function for a scimax-contact.
-Optional argument ARG is ingored."
+Optional argument ARG is ignored."
   (let* ((contacts (org-db-contacts-candidates))
 	 (contact (cdr (assoc (completing-read "Contact: " contacts) contacts))))
     (org-link-store-props

--- a/scimax-dashboard.el
+++ b/scimax-dashboard.el
@@ -146,7 +146,7 @@
    :button-prefix ""
    :button-suffix ""
    :format "%[%t%]"
-   "scimax (Github)")
+   "scimax (GitHub)")
 
   (insert "    ")
   (widget-create

--- a/scimax-editmarks.org
+++ b/scimax-editmarks.org
@@ -1982,7 +1982,7 @@ the current version. Returns the buffer."
 
 *** TODO Saving the generated wdiff buffer back
 
- The idea here is you you can do accept/reject in the temporary buffer, and then save it back. If you mess up badly, just delete the temp buffer. This needs to be tested.
+ The idea here is you can do accept/reject in the temporary buffer, and then save it back. If you mess up badly, just delete the temp buffer. This needs to be tested.
 
  #+BEGIN_SRC emacs-lisp
 (defun sem-wdiff-save ()

--- a/scimax-editmarks.org
+++ b/scimax-editmarks.org
@@ -107,7 +107,7 @@ comment <<}
 
 {>~ @author comment~<}
 
-** Replys
+** Replies
 
 {r> @replier A reply<r}
 

--- a/scimax-editmarks.org
+++ b/scimax-editmarks.org
@@ -2133,7 +2133,7 @@ changed."
       2. Fresh delete, insert markers and put content in them. [[(delete-2-new)]]
       3. At the beginning of a delete, and deleting. Push deletion to front of content. [[(delete-2-front)]].
       4. At the beginning of a delete and end of another delete. merge them. [[(delete-2-merge)]].
-      5. At the beginning of a delete and end of another mark. Just move in to previous mark. [[(delete-2-end+mark)]].
+      5. At the beginning of a delete and end of another mark. Just move it to previous mark. [[(delete-2-end+mark)]].
       6. At the end of a delete, but not looking at another mark. Jump to the front. [[(delete-2-end-extend)]]
 
 

--- a/scimax-functional-text.el
+++ b/scimax-functional-text.el
@@ -23,7 +23,7 @@
 ;; Hashtags: #MeToo
 ;; @Usernames
 ;;
-;; Github issues: issue #153
+;; GitHub issues: issue #153
 ;; git commits:  commit 05fcea6
 ;; pull requests: pr #146  pull #146  or pull request #146
 
@@ -143,7 +143,7 @@ _c_: Contacts _m_: Mail
 
 ;; * Username handles
 ;;
-;; These may have many contexts, e.g. Twitter, Github, etc. The action on these
+;; These may have many contexts, e.g. Twitter, GitHub, etc. The action on these
 ;;  is to launch a hydra menu to pick which action you want.
 ;;
 ;; @johnkitchin   (twitter)
@@ -174,7 +174,7 @@ URL-PATTERN should have one %s in it which is replaced by username."
   "
 Open a @username
 _b_: Bitbucket  _f_: Facebook
-_g_: GitHUB     _i_: Instagram
+_g_: GitHub     _i_: Instagram
 _G_: GitLab     _l_: LinkedIn _r_: reddit  _t_: Twitter
 "
   ("b" (@username-open "https://bitbucket.org/%s/"))
@@ -237,8 +237,8 @@ These are words that start with #."
    :help-echo "Click me to open the hashtag."))
 
 
-;; * Github
-;; ** Github issues
+;; * GitHub
+;; ** GitHub issues
 ;; When the link in a git repo, make it open the issue.
 ;; issue #153 -> https://github.com/jkitchin/scimax/issues/153
 (defvar github-issue-regexp "issue\\s-+#\\(?1:[0-9]+\\)"
@@ -247,7 +247,7 @@ These are words that start with #."
 (defhydra github-issue (:color blue :hint nil)
   "
 git issue
-_g_: Github"
+_g_: GitHub"
   ("g" (lambda ()
 	 (interactive)
 	 (when-let (url (github-issue-at-p))
@@ -275,9 +275,9 @@ _g_: Github"
    github-issue-regexp
    'github-issue/body
    :face (list 'link)
-   :help-echo "Click me to open issue at Github."))
+   :help-echo "Click me to open issue at GitHub."))
 
-;; ** Github pull requests
+;; ** GitHub pull requests
 ;; pull request #146
 ;; pull #146
 ;; pr #146
@@ -304,7 +304,7 @@ _g_: Github"
 (defhydra github-pull-request (:color blue :hint nil)
   "
 git pull-request
-_g_: Github"
+_g_: GitHub"
   ("g" (lambda ()
 	 (interactive)
 	 (when-let (url (pull-request-at-p))
@@ -316,9 +316,9 @@ _g_: Github"
    pull-request-regexp
    'github-pull-request/body
    :face (list 'link)
-   :help-echo "Click me to open pull request at Github."))
+   :help-echo "Click me to open pull request at GitHub."))
 
-;; ** Github commits
+;; ** GitHub commits
 ;; Open a commit in a browser.
 ;; commit 15b8adf1 -> https://github.com/jkitchin/scimax/commit/15b8adf191a252bb6a4c16c327f9c6fccc315a73
 ;; commit 05fcea6
@@ -344,7 +344,7 @@ _g_: Github"
 (defhydra git-commit (:color blue :hint nil)
   "
 commit
-_g_: Github _m_: Magit log
+_g_: GitHub _m_: Magit log
 ^ ^         _c_: Magit commit"
   ("c" (magit-show-commit (third (github-commit-at-p))))
   ("g" (when-let ((data (github-commit-at-p))
@@ -359,7 +359,7 @@ _g_: Github _m_: Magit log
    github-commit-regexp
    'git-commit/body
    :face (list 'link)
-   :help-echo "Click me to open the commit on Github."))
+   :help-echo "Click me to open the commit on GitHub."))
 
 (provide 'scimax-functional-text)
 

--- a/scimax-gitter.el
+++ b/scimax-gitter.el
@@ -3,7 +3,7 @@
 ;;; Commentary:
 ;; This library provides some integration of Emacs/org-mode and gitter.
 ;;
-;; You need a like like this in your ~/.authinfo
+;; You need a line like this in your ~/.authinfo
 ;; machine gitter.im password token
 ;;
 ;; where token comes from going to https://developer.gitter.im/apps

--- a/scimax-hydra.el
+++ b/scimax-hydra.el
@@ -1272,7 +1272,7 @@ _/_: directories  _M_: chmod
 _@_: symlinks     _G_: chgrp
 _O_: omitted      _O_: chown
 ----
-_U_: unmark all   _A_: find regx
+_U_: unmark all   _A_: find regex
 _t_: toggle marks _Q_: find/rep
 "
   ;; marking

--- a/scimax-hydra.el
+++ b/scimax-hydra.el
@@ -414,7 +414,7 @@ _p_: ffap
   ("b" counsel-ibuffer "Buffer" :column "misc")
   ("n" ace-window "Ace window" :column "misc")
   ("f" counsel-recentf "Recent file" :column "misc")
-  ("j" avy-goto-char-timer "avy timer" :coumn "misc")
+  ("j" avy-goto-char-timer "avy timer" :column "misc")
   )
 
 

--- a/scimax-hydra.el
+++ b/scimax-hydra.el
@@ -606,7 +606,7 @@ _<tab>_: %(ring-ref scimax-hydra-modes (+ 1 scimax-hydra-mode-counter)) _S-<tab>
   ("z" (scimax-open-hydra scimax-jump/body) :color blue)
   ("H-w" backward-word)
   ("H-s" backward-sentence)
-  ("H-p" backaward-paragraph)
+  ("H-p" backward-paragraph)
   ("s-p" forward-paragraph)
   ("s-w" forward-word)
   ("s-s" forward-sentence)

--- a/scimax-ipython.org
+++ b/scimax-ipython.org
@@ -3,7 +3,7 @@
 
 * Updates to ipython in scimax
 
-Scimax has used a forked version ob-ipython for a long time. The upstream version has improved a lot over the last year, and is nicer than my forked version, especially for asynchronous blocks. So.... I have been working to integrate the upstream version and replace my forked version. Well, mostly. I have specific things I want in org-mode/ipython integration that aren't built in to ob-ipython, and aren't customizable either. So, my new integration still monkey patches quite a few ob-ipython functions.
+Scimax has used a forked version ob-ipython for a long time. The upstream version has improved a lot over the last year, and is nicer than my forked version, especially for asynchronous blocks. So.... I have been working to integrate the upstream version and replace my forked version. Well, mostly. I have specific things I want in org-mode/ipython integration that aren't built into ob-ipython, and aren't customizable either. So, my new integration still monkey patches quite a few ob-ipython functions.
 
 The new update is in two files: [[./scimax-ob.el]], which contains pretty general functions for all org babel src blocks I think, and [[./scimax-org-babel-ipython-upstream.el]] which contains monkey-patches on ob-ipython, and additional features.
 

--- a/scimax-ivy.el
+++ b/scimax-ivy.el
@@ -117,7 +117,7 @@
 ;; 
 ;; I wrote this because some commands have so many alternate actions
 ;; they are not all visible, and in those cases using completion is
-;; preferrable to scanning a lot of options.
+;; preferable to scanning a lot of options.
 
 ;; (defun scimax-ivy-alternate ()
 ;;   "Run an alternate selection on the current candidate with completion.

--- a/scimax-journal.el
+++ b/scimax-journal.el
@@ -267,7 +267,7 @@ open in the default journal even if there is a local journal."
   (let* ((fname (buffer-file-name))
 	 (tree (scimax-journal-entries)))
     (if (not (avl-tree-member tree fname))
-	(messsage "%s doesn't seem to be a journal file. Not deleting.")
+	(message "%s doesn't seem to be a journal file. Not deleting.")
       (when (y-or-n-p (format "Really delete %s? " fname)))
       ;; Now we delete it.
       (avl-tree-delete tree fname)

--- a/scimax-jupyter.el
+++ b/scimax-jupyter.el
@@ -169,7 +169,7 @@ Otherwise, wrap it in an export block."
 
 
 ;; used to advise `jupyter-org-sync-results'. I do this to fix some issues like
-;; retults drawers, etc.
+;; results drawers, etc.
 (defun scimax-jupyter-org-sync-results (req)
   "Return the result string in org syntax for the results of REQ.
 Meant to be used as the return value of

--- a/scimax-jupyter.el
+++ b/scimax-jupyter.el
@@ -168,7 +168,7 @@ Otherwise, wrap it in an export block."
   (jupyter-org-export-block type value))
 
 
-;; used to advise `jupyter-org-sync-results'. I do this to fix some issues liek
+;; used to advise `jupyter-org-sync-results'. I do this to fix some issues like
 ;; retults drawers, etc.
 (defun scimax-jupyter-org-sync-results (req)
   "Return the result string in org syntax for the results of REQ.

--- a/scimax-lob/lob.org
+++ b/scimax-lob/lob.org
@@ -559,7 +559,7 @@ Fraga.  It was modified slightly by Tom Dye.
 | CSS        | css        | ditaa          | ditaa      |
 | Graphviz   | dot        | Emacs Lisp     | emacs-lisp |
 | gnuplot    | gnuplot    | Haskell        | haskell    |
-| Javascript | js         | LaTeX          | latex      |
+| JavaScript | js         | LaTeX          | latex      |
 | Ledger     | ledger     | Lisp           | lisp       |
 | Lilypond   | lilypond   | MATLAB         | matlab     |
 | Mscgen     | mscgen     | Objective Caml | ocaml      |

--- a/scimax-md/scimax-md.md
+++ b/scimax-md/scimax-md.md
@@ -25,7 +25,7 @@
 
 Why? Don't we already have org-mode? Yes, but some places like Markdown, it is no fun to write when you have really technical documents, and it would be harder to get markdown-mode to be as good as org-mode than to do this.
 
-Github's rendering of org-mode is only ok. Too many things like references, internal links, etc. don't work though to rely on it for high quality documentation in the browser. This might be a nicer way to get better Github pages. Why not just use html then? Some places like markdown.
+GitHub's rendering of org-mode is only ok. Too many things like references, internal links, etc. don't work though to rely on it for high quality documentation in the browser. This might be a nicer way to get better GitHub pages. Why not just use html then? Some places like markdown.
 
 
 <a id="org3536353"></a>
@@ -118,7 +118,7 @@ Suppose you have this equation to solve:
 
 \[8 = x - 4\]  <a name="eq-sle"></a>
 
-You can put a label near this and refer to it later. I guess Github does not do a great job rendering equations.
+You can put a label near this and refer to it later. I guess GitHub does not do a great job rendering equations.
 
 
 <a id="org6a858e9"></a>
@@ -261,7 +261,7 @@ Tables are numbered in the export, but they export as html, and it is the org-ht
 
 # Citations  <a name="sec-citations"></a>
 
-You can have proper scientific citations like this <sup id="9e3ad98c9008c49c9d14834ca3913eb6"><a href="#kitchin-2015-examp" title="Kitchin, Examples of Effective Data Sharing in Scientific Publishing, {ACS Catalysis}, v(6), 3894-3899 (2015).">kitchin-2015-examp</a></sup>, including multiple references <sup id="66b54b1976758a93506a846c2666419b"><a href="#kitchin-2015-data-surfac-scien" title="John Kitchin, Data Sharing in Surface Science, Surface Science , v(), 103-107 (2016).">kitchin-2015-data-surfac-scien</a></sup><sup>,</sup><sup id="9e3ad98c9008c49c9d14834ca3913eb6"><a href="#kitchin-2015-examp" title="Kitchin, Examples of Effective Data Sharing in Scientific Publishing, {ACS Catalysis}, v(6), 3894-3899 (2015).">kitchin-2015-examp</a></sup><sup>,</sup><sup id="fe4ece7c7b3687ca21f32c0ee4e0a542"><a href="#kitchin-2016-autom-data" title="Kitchin, Van Gulick \&amp; Zilinski, Automating Data Sharing Through Authoring Tools, International Journal on Digital Libraries, v(2), 93--98 (2016).">kitchin-2016-autom-data</a></sup>. Check out the tooltips on them in the html that Github renders. Somewhat unfortunately, the citations are exported basically as html, so they are not fun to read in the markdown. Oh well, did I mention tooltips!
+You can have proper scientific citations like this <sup id="9e3ad98c9008c49c9d14834ca3913eb6"><a href="#kitchin-2015-examp" title="Kitchin, Examples of Effective Data Sharing in Scientific Publishing, {ACS Catalysis}, v(6), 3894-3899 (2015).">kitchin-2015-examp</a></sup>, including multiple references <sup id="66b54b1976758a93506a846c2666419b"><a href="#kitchin-2015-data-surfac-scien" title="John Kitchin, Data Sharing in Surface Science, Surface Science , v(), 103-107 (2016).">kitchin-2015-data-surfac-scien</a></sup><sup>,</sup><sup id="9e3ad98c9008c49c9d14834ca3913eb6"><a href="#kitchin-2015-examp" title="Kitchin, Examples of Effective Data Sharing in Scientific Publishing, {ACS Catalysis}, v(6), 3894-3899 (2015).">kitchin-2015-examp</a></sup><sup>,</sup><sup id="fe4ece7c7b3687ca21f32c0ee4e0a542"><a href="#kitchin-2016-autom-data" title="Kitchin, Van Gulick \&amp; Zilinski, Automating Data Sharing Through Authoring Tools, International Journal on Digital Libraries, v(2), 93--98 (2016).">kitchin-2016-autom-data</a></sup>. Check out the tooltips on them in the html that GitHub renders. Somewhat unfortunately, the citations are exported basically as html, so they are not fun to read in the markdown. Oh well, did I mention tooltips!
 
 org-ref helps you insert citations from a bibtex database.
 

--- a/scimax-md/scimax-md.org
+++ b/scimax-md/scimax-md.org
@@ -2,7 +2,7 @@
 
 Why? Don't we already have org-mode? Yes, but some places like Markdown, it is no fun to write when you have really technical documents, and it would be harder to get markdown-mode to be as good as org-mode than to do this.
 
-Github's rendering of org-mode is only ok. Too many things like references, internal links, etc. don't work though to rely on it for high quality documentation in the browser. This might be a nicer way to get better Github pages. Why not just use html then? Some places like markdown.
+GitHub's rendering of org-mode is only ok. Too many things like references, internal links, etc. don't work though to rely on it for high quality documentation in the browser. This might be a nicer way to get better GitHub pages. Why not just use html then? Some places like markdown.
 
 * Headings
 
@@ -66,7 +66,7 @@ Suppose you have this equation to solve:
 
 $$8 = x - 4$$  label:eq-sle
 
-You can put a label near this and refer to it later. I guess Github does not do a great job rendering equations.
+You can put a label near this and refer to it later. I guess GitHub does not do a great job rendering equations.
 
 * Code blocks
 
@@ -133,7 +133,7 @@ Tables are numbered in the export, but they export as html, and it is the org-ht
 
 * Citations  label:sec-citations
 
-You can have proper scientific citations like this cite:kitchin-2015-examp, including multiple references cite:kitchin-2015-data-surfac-scien,kitchin-2015-examp,kitchin-2016-autom-data. Check out the tooltips on them in the html that Github renders. Somewhat unfortunately, the citations are exported basically as html, so they are not fun to read in the markdown. Oh well, did I mention tooltips!
+You can have proper scientific citations like this cite:kitchin-2015-examp, including multiple references cite:kitchin-2015-data-surfac-scien,kitchin-2015-examp,kitchin-2016-autom-data. Check out the tooltips on them in the html that GitHub renders. Somewhat unfortunately, the citations are exported basically as html, so they are not fun to read in the markdown. Oh well, did I mention tooltips!
 
 org-ref helps you insert citations from a bibtex database.
 

--- a/scimax-notebook.org
+++ b/scimax-notebook.org
@@ -748,7 +748,7 @@ I often want to make links between projects. For example, I may have notes in a 
 
 We need a different kind of link that allows you to specify a project, and a file in that project. Then, when you follow the link, it will look up the project in your list of known projects to get the root directory for it, and then construct a path to the file from that.
 
-Here we define a new org-link for making links to files in notebooks. These links will look like nb:project-name::relative-file-path::link-target. If the target is not existent, the link will be red.
+Here we define a new org-link for making links to files in notebooks. These links will look like nb:project-name::relative-file-path::link-target. If the target is nonexistent, the link will be red.
 
 - project-name :: Name of project, usually at the end of the absolute path to the project directory.
 - relative-file-path :: Path to a file, usually relative to the project root

--- a/scimax-notebook.org
+++ b/scimax-notebook.org
@@ -158,7 +158,7 @@ We store all projects by default in nb-notebook-directory. You can use nested di
 	       (shell-command "git init")
 	       ;; We also should have a .projectile. I think this will make some
 	       ;; searches work on files not committed to the git repo. In any
-	       ;; case, it should not hurt anythin.
+	       ;; case, it should not hurt anything.
 	       (shell-command "touch .projectile")))
 	    ((eq 'projectile nb-project-type)
 	     (let ((default-directory dir))

--- a/scimax-org-babel-ipython-upstream.el
+++ b/scimax-org-babel-ipython-upstream.el
@@ -47,7 +47,7 @@ If non-nil do not show the execution count in output."
   "Function for showing the execution count.
 The function takes one argument, the execution count. It should return a string to be displayed. Use an empty string to suppress the count.
 `ob-ipython-execution-count-suppress' will not show anything.
-`ob-ipython-execution-count-output' will show a string in the ouput.
+`ob-ipython-execution-count-output' will show a string in the output.
 `ob-ipython-execution-count-overlay' will show an overlay in the margin.
 `ob-ipython-execution-count-attribute' will store it in a src-block attribute."
   :group 'ob-ipython
@@ -609,7 +609,7 @@ _s_: save buffer  _z_: undo _<return>_: edit mode
   ;; this folds output
   ("o" ob-ipython-toggle-output "toggle output" :color red)
 
-  ;; for large ouputs, puts results in a window you can scroll in. Not sure if
+  ;; for large outputs, puts results in a window you can scroll in. Not sure if
   ;; that is possible in emacs. May be no analog.
   ;; ( ;; "S-o" "toggle output scrolling"
   ;;  )

--- a/scimax-org-images.el
+++ b/scimax-org-images.el
@@ -7,7 +7,7 @@
 ;; org-mode. 1. On Windows, emacs is not always built with imagemagick support.
 ;; This library enables you to use an external program from imagemagick to build
 ;; the thumbnails required to show images. 2. It expands the ways you can resize
-;; an image to supprot more options from mogrify.
+;; an image to support more options from mogrify.
 
 ;;; Code:
 

--- a/scimax-org-latex.el
+++ b/scimax-org-latex.el
@@ -52,7 +52,7 @@
 	("" "amsmath" t)
 	("theorems, skins" "tcolorbox" t)
 
-	;; used for marking up chemical formulars
+	;; used for marking up chemical formulas
 	("version=3" "mhchem" t)
 
 	("numbers,super,sort&compress" "natbib" nil)

--- a/scimax-twitter.el
+++ b/scimax-twitter.el
@@ -530,9 +530,9 @@ Any link will count 23 characters."
 
 
 ;; * Exporter
-;; http://qaz.wtf/u/convert.cgi?text=ABCDEFGHIJKLMNOPQRSTUVWZYZabcdefghijklmnopqrstuvwxyz0123456789
+;; http://qaz.wtf/u/convert.cgi?text=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789
 (defun scimax-twitter-filter-bold (text back-end info)
-  (let ((plain "ABCDEFGHIJKLMNOPQRSTUVWZYZabcdefghijklmnopqrstuvwxyz0123456789")
+  (let ((plain "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 	(ubold "𝐀𝐁𝐂𝐃𝐄𝐅𝐆𝐇𝐈𝐉𝐊𝐋𝐌𝐍𝐎𝐏𝐐𝐑𝐒𝐓𝐔𝐕𝐖𝐗𝐘𝐙𝐚𝐛𝐜𝐝𝐞𝐟𝐠𝐡𝐢𝐣𝐤𝐥𝐦𝐧𝐨𝐩𝐪𝐫𝐬𝐭𝐮𝐯𝐰𝐱𝐲𝐳𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗")
 	i)
     (replace-regexp-in-string "*" ""
@@ -546,7 +546,7 @@ Any link will count 23 characters."
 
 
 (defun scimax-twitter-filter-italic (text back-end info)
-  (let ((plain "ABCDEFGHIJKLMNOPQRSTUVWZYZabcdefghijklmnopqrstuvwxyz0123456789")
+  (let ((plain "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 	(uitalic "𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍𝑎𝑏𝑐𝑑𝑒𝑓𝑔ℎ𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧")
 	i)
     (replace-regexp-in-string "/" ""
@@ -560,7 +560,7 @@ Any link will count 23 characters."
 
 
 (defun scimax-twitter-filter-verbatim (text back-end info)
-  (let ((plain "ABCDEFGHIJKLMNOPQRSTUVWZYZabcdefghijklmnopqrstuvwxyz0123456789")
+  (let ((plain "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 	(uverbatim "𝙰𝙱𝙲𝙳𝙴𝙵𝙶𝙷𝙸𝙹𝙺𝙻𝙼𝙽𝙾𝙿𝚀𝚁𝚂𝚃𝚄𝚅𝚆𝚉𝚈𝚉𝚊𝚋𝚌𝚍𝚎𝚏𝚐𝚑𝚒𝚓𝚔𝚕𝚖𝚗𝚘𝚙𝚚𝚛𝚜𝚝𝚞𝚟𝚠𝚡𝚢𝚣𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿")
 	i)
     (replace-regexp-in-string

--- a/scimax-twitter.el
+++ b/scimax-twitter.el
@@ -643,7 +643,7 @@ Any link will count 23 characters."
 
 ;; The Twitter API for scheduling tweets is not that easy to use, and you have
 ;; to register as an advertiser. Rather than do that, here I try to leverage the
-;; at scheduler (avialiable on Mac and Linux) to do scheduling of tweets. The
+;; at scheduler (available on Mac and Linux) to do scheduling of tweets. The
 ;; idea is to use teh scheduled property on a headline to specify when to tweet
 ;; it, then create a shell script that runs to tweet it. This is limited to a
 ;; single image I think.

--- a/scimax-utils.el
+++ b/scimax-utils.el
@@ -285,13 +285,13 @@ You can also try putting expressions in for formatting, e.g.:
 
 
 (defun scimax-github ()
-  "Open the Github repo."
+  "Open the GitHub repo."
   (interactive)
   (browse-url "https://github.com/jkitchin/scimax"))
 
 
 (defun scimax-github-issues ()
-  "Open the Github repo issues page."
+  "Open the GitHub repo issues page."
   (interactive)
   (browse-url "https://github.com/jkitchin/scimax/issues"))
 

--- a/scimax-utils.el
+++ b/scimax-utils.el
@@ -302,7 +302,7 @@ You can also try putting expressions in for formatting, e.g.:
   "Take a screenshot and insert org link.
 with prefix arg, minimize emacs first.
 with double prefix arg, prompt for filename.
-Only works on Mac OSX."
+Only works on macOS."
   (interactive "P")
   (when arg
     (suspend-frame))
@@ -374,7 +374,7 @@ ARG prompt for filename, else generate one. images are saved in
   "Take a screenshot and insert org link.
 with prefix arg, minimize emacs first.
 With a double prefix, prompt for the filename.
-Only works on Mac OSX."
+Only works on macOS."
   (interactive "P")
   (when arg
     (suspend-frame))

--- a/scimax.el
+++ b/scimax.el
@@ -62,7 +62,7 @@ Set to nil to avoid loading a theme."
   (let ((default-directory scimax-dir))
     (when (not (string= "" (shell-command-to-string "git status --porcelain")))
       (shell-command "git add *")
-      (shell-command "git commit -am \"commiting scimax.\""))
+      (shell-command "git commit -am \"committing scimax.\""))
     (shell-command "git pull origin master")
     (shell-command "git submodule update")
     (load-file "init.el")))

--- a/scimax.org
+++ b/scimax.org
@@ -1290,7 +1290,7 @@ If you like sessions in Python, the ob-ipython library is better than the defaul
 
 Pygments doesn't support ipython out of the box for some reason, which is a problem if you want to export your src block to LaTeX. scimax fixes this for you and automatically installs this if you don't already have it.
 
-ob-ipython allows you to use Ipython magic commands in your src blocks. Here is a protypical Ipython src block with a line magic.
+ob-ipython allows you to use Ipython magic commands in your src blocks. Here is a sample Ipython src block with a line magic.
 
 #+BEGIN_SRC ipython  :exports both
 %time print("hello world")

--- a/scimax.org
+++ b/scimax.org
@@ -1464,7 +1464,7 @@ scimax provides the jupyter-hy src block to run hylang in src blocks. The requir
 
 * RSS feeds
 
-It is a major challenge to keep up with the scientific literature. `elfeed' is the package we use in scimax for that. It aggregates RSS feeds and provides a pretty easy way to consume them, capture them in to org-mode, search them, and do things with them. scimax preconfigures elfeed with some python, and emacs feeds, and you can easily add new feeds:
+It is a major challenge to keep up with the scientific literature. `elfeed' is the package we use in scimax for that. It aggregates RSS feeds and provides a pretty easy way to consume them, capture them into org-mode, search them, and do things with them. scimax preconfigures elfeed with some python, and emacs feeds, and you can easily add new feeds:
 
 The scimax customizations of elfeed are not loaded by default. If you want them, you have to add this to  your init files.:
 

--- a/scimax.org
+++ b/scimax.org
@@ -1211,7 +1211,7 @@ In an open file run ~M-x git-blame~, then press b to see commits that add lines.
   In magit-status window, press "W"
 
   "W p" creates patches
-  "W r" makes a pull request. This just creates an email with information in it. It is not a GitHUB request, and it is only useful if there is a public, external copy of the repo.
+  "W r" makes a pull request. This just creates an email with information in it. It is not a GitHub request, and it is only useful if there is a public, external copy of the repo.
 
 *** Cherry-picking
 

--- a/scimax.org
+++ b/scimax.org
@@ -1194,7 +1194,7 @@ In an open file run ~M-x git-blame~, then press b to see commits that add lines.
 
   [[info:magit#Rebasing][info:magit#Rebasing]]
 
-**** Interactve rebasing
+**** Interactive rebasing
 
  Open the log, select the oldest commit you want to rebase on then press "r" and then "i". Use M-p and M-n to move commits around. Press "s" on any commits you want to squash into the commit above it. C-c C-c will start the commands.
 

--- a/snippets/org-mode/kitchingroup/ms-readme
+++ b/snippets/org-mode/kitchingroup/ms-readme
@@ -19,7 +19,7 @@ There should be a directory called [[./reports]] which will contain subdirectori
 
 * Using this repo
 
-The documents in this repo are in a version control system (VCS) called git. You have a local copy of them which you can edit. When you are done, you save the files, commit them to the VCS and push the changes to Github. Then, I can pull your changes to my copy, review them, add comments, etc. When I am done, I will push my edits back to GitHUB. You can then pull my changes down for your review.
+The documents in this repo are in a version control system (VCS) called git. You have a local copy of them which you can edit. When you are done, you save the files, commit them to the VCS and push the changes to GitHub. Then, I can pull your changes to my copy, review them, add comments, etc. When I am done, I will push my edits back to GitHub. You can then pull my changes down for your review.
 
 It will take some practice and some time to understand how it all works.
 

--- a/subfiles/scimax-org-subfiles.el
+++ b/subfiles/scimax-org-subfiles.el
@@ -16,7 +16,7 @@
 ;;
 ;; Use `sos-export-as-pdf-and-open' C-c C-e s o in any file to build the PDF.
 ;;
-;; Inspired by personal correspondance with Nicky van Foreest.
+;; Inspired by personal correspondence with Nicky van Foreest.
 
 
 ;;; Code:

--- a/words.el
+++ b/words.el
@@ -90,7 +90,7 @@ Do not include the translate language here, it is added in
 
 
 (defcustom words-translate-preferred-language nil
-  "A two letter language code for the preferred languate to translate to.
+  "A two letter language code for the preferred language to translate to.
 See http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry."
   :group 'words)
 

--- a/words.el
+++ b/words.el
@@ -342,7 +342,7 @@ Not every language is supported.
 The translation will appear as a message.
 
 If `words-translate-speak' is non-nil, or a double prefix arg is
-used the translation will be read outloud by `words-speak'.
+used the translation will be read aloud by `words-speak'.
 
 Note: there are usage limits of 1000
 words/day (https://mymemory.translated.net/doc/usagelimits.php)."


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/scimax/actions/runs/4870186792#summary-13196829839

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/scimax/actions/runs/4870186748#summary-13196830541

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

This is a follow-up to #451. I've mostly performed a rebase for the fixes, there were only a couple of items that were new.

If you'd like me to drop things in "deprecated" or other paths, please let me know. I'm more than happy to drop things. If at some point you actually _like_ the changes, I'm quite happy to squash the commits together. I do not squash eagerly as I assume that people will find at least some of my changes controversial.

Note that for this, I redid the work to calculate which things to ignore (the engine for check-spelling has improved significantly since the previous PR).